### PR TITLE
[16.0][IMP] stock_release_channel_shipment_advice_deliver: Improve some features with auto_deliver

### DIFF
--- a/stock_release_channel_shipment_advice_deliver/models/shipment_advice.py
+++ b/stock_release_channel_shipment_advice_deliver/models/shipment_advice.py
@@ -97,3 +97,10 @@ class ShipmentAdvice(models.Model):
             ):
                 rec.release_channel_id.state = "delivering"
         return super().action_done()
+
+    def action_in_progress(self):
+        res = super().action_in_progress()
+        self.release_channel_id.filtered(
+            "is_action_deliver_allowed"
+        ).state = "delivering"
+        return res

--- a/stock_release_channel_shipment_advice_deliver/views/stock_release_channel.xml
+++ b/stock_release_channel_shipment_advice_deliver/views/stock_release_channel.xml
@@ -33,6 +33,11 @@
             <field name="release_forbidden" position="after">
                 <field name="auto_deliver" />
             </field>
+            <button name="button_plan_shipments" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('can_plan_shipment', '=', False), ('auto_deliver', '=', True)]}</attribute>
+            </button>
         </field>
     </record>
     <record model="ir.ui.view" id="stock_release_channel_search_view">
@@ -61,5 +66,48 @@
         >{'search_default_filter_open': True, 'search_default_filter_locked': True, 'search_default_filter_delivering': True}</field>
     </record>
 
+    <record model="ir.ui.view" id="stock_release_channel_kanban_view">
+        <field name="model">stock.release.channel</field>
+        <field
+            name="inherit_id"
+            ref="stock_release_channel.stock_release_channel_kanban_view"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[hasclass('o_kanban_card_manage_title')]"
+                position="after"
+            >
+                <field name="is_action_deliver_allowed" invisible="1" />
+                <t t-if="record.is_action_deliver_allowed.raw_value">
+                    <div role="menuitem">
+                        <a name="action_deliver" type="object" icon="fa-truck"><span
+                                class="ms-2"
+                            >Deliver</span></a>
+                    </div>
+                </t>
+            </xpath>
+       </field>
+    </record>
+
+    <record model="ir.ui.view" id="stock_release_channel_kanban_view_2">
+        <field name="model">stock.release.channel</field>
+        <field
+            name="inherit_id"
+            ref="stock_release_channel_shipment_advice.stock_release_channel_kanban_view"
+        />
+        <field name="arch" type="xml">
+            <field name="can_plan_shipment" position="after">
+                <field name="auto_deliver" invisible="1" />
+            </field>
+            <xpath
+                expr="//t[@t-if='record.can_plan_shipment.raw_value']"
+                position="attributes"
+            >
+                <attribute
+                    name="t-if"
+                >record.can_plan_shipment.raw_value and !record.auto_deliver.raw_value</attribute>
+            </xpath>
+        </field>
+    </record>
 
 </odoo>


### PR DESCRIPTION
- Show button 'Deliver' in the kanban view
- Show button 'Plan Shipment' if not auto deliver
- Update state of release channel to 'delivering' when the related shipment advice starts