### PR TITLE
[FIX] stock_release_channel_shipment_advice_deliver: allow to deliver with a picking backorder

### DIFF
--- a/stock_release_channel_shipment_advice_deliver/models/stock_release_channel.py
+++ b/stock_release_channel_shipment_advice_deliver/models/stock_release_channel.py
@@ -179,7 +179,7 @@ class StockReleaseChannel(models.Model):
         self._deliver_cleanup_printed()
         moves_to_unrelease = self._shipping_moves_to_unrelease()
         if moves_to_unrelease:
-            if any(not m.unrelease_allowed for m in moves_to_unrelease):
+            if any(not m._is_unreleaseable() for m in moves_to_unrelease):
                 self._deliver_check_no_picking_printed()
                 raise UserError(
                     _(
@@ -199,11 +199,14 @@ class StockReleaseChannel(models.Model):
                 "target": "new",
                 "context": {"default_release_channel_id": self.id, **self.env.context},
             }
+        self._action_deliver()
+        return {}
+
+    def _action_deliver(self):
         self.write({"state": "delivering", "delivering_error": False})
         self.with_delay(
             description=_("Delivering release channel %(name)s.", name=self.name)
-        )._action_deliver()
-        return {}
+        )._process_shipments()
 
     def action_delivering_error(self):
         self._check_is_action_delivering_error_allowed()
@@ -232,7 +235,7 @@ class StockReleaseChannel(models.Model):
             sticky=True,
         )
 
-    def _action_deliver(self):
+    def _process_shipments(self):
         self.ensure_one()
         shipment_advice = self.in_process_shipment_advice_ids.filtered(
             lambda s: s.state in ("in_progress", "error")

--- a/stock_release_channel_shipment_advice_deliver/tests/test_stock_release_channel_deliver.py
+++ b/stock_release_channel_shipment_advice_deliver/tests/test_stock_release_channel_deliver.py
@@ -26,7 +26,7 @@ class TestStockReleaseChannelDeliver(TestStockReleaseChannelDeliverCommon):
         with trap_jobs() as trap_rc:
             self.channel.action_deliver()
             self.assertEqual(self.channel.state, "delivering")
-            trap_rc.assert_enqueued_job(self.channel._action_deliver)
+            trap_rc.assert_enqueued_job(self.channel._process_shipments)
             with trap_jobs() as trap_sa:
                 trap_rc.perform_enqueued_jobs()
                 advices = self.channel.shipment_advice_ids.filtered(
@@ -62,7 +62,7 @@ class TestStockReleaseChannelDeliver(TestStockReleaseChannelDeliverCommon):
         with trap_jobs() as trap_rc:
             self.channel.action_deliver()
             self.assertEqual(self.channel.state, "delivering")
-            trap_rc.assert_enqueued_job(self.channel._action_deliver)
+            trap_rc.assert_enqueued_job(self.channel._process_shipments)
             with trap_jobs() as trap_sa:
                 trap_rc.perform_enqueued_jobs()
                 shipment_advice = self.channel.shipment_advice_ids
@@ -151,7 +151,7 @@ class TestStockReleaseChannelDeliver(TestStockReleaseChannelDeliverCommon):
         with trap_jobs() as trap_rc:
             wizard.action_deliver()
             self.assertEqual(self.channel.state, "delivering")
-            trap_rc.assert_enqueued_job(self.channel._action_deliver)
+            trap_rc.assert_enqueued_job(self.channel._process_shipments)
             with trap_jobs() as trap_sa:
                 trap_rc.perform_enqueued_jobs()
                 shipment_advice = self.channel.shipment_advice_ids
@@ -212,3 +212,20 @@ class TestStockReleaseChannelDeliver(TestStockReleaseChannelDeliverCommon):
         shipment_advice.action_confirm()
         shipment_advice.action_in_progress()
         self.assertEqual(self.channel.state, "delivering")
+
+    def test_deliver_partial_pick_with_bo(self):
+        """Partial picking with backorder creation.
+
+        Deliver must be allowed"""
+        # Process 2 out of 5
+        self.internal_pickings.picking_type_id.create_backorder = "always"
+        for move in self.internal_pickings[0].move_ids:
+            move.quantity_done = 2
+        self.internal_pickings[0].button_validate()
+        res = self.channel.action_deliver()
+        self.assertIsInstance(res, dict)
+        wizard = (
+            self.env[res.get("res_model")].with_context(**res.get("context")).create({})
+        )
+        wizard.with_context(test_queue_job_no_delay=True).action_deliver()
+        self.assertEqual(self.channel.state, "delivered")

--- a/stock_release_channel_shipment_advice_deliver/tests/test_stock_release_channel_deliver_async.py
+++ b/stock_release_channel_shipment_advice_deliver/tests/test_stock_release_channel_deliver_async.py
@@ -21,7 +21,7 @@ class TestStockReleaseChannelDeliverAsync(TestStockReleaseChannelDeliverCommon):
         with trap_jobs() as trap_rc:
             self.channel.action_deliver()
             self.assertEqual(self.channel.state, "delivering")
-            trap_rc.assert_enqueued_job(self.channel._action_deliver)
+            trap_rc.assert_enqueued_job(self.channel._process_shipments)
             with trap_jobs() as trap_sa:
                 trap_rc.perform_enqueued_jobs()
                 advices = self.channel.shipment_advice_ids.filtered(
@@ -62,7 +62,7 @@ class TestStockReleaseChannelDeliverAsync(TestStockReleaseChannelDeliverCommon):
         with trap_jobs() as trap_rc:
             self.channel.action_deliver()
             self.assertEqual(self.channel.state, "delivering")
-            trap_rc.assert_enqueued_job(self.channel._action_deliver)
+            trap_rc.assert_enqueued_job(self.channel._process_shipments)
             with trap_jobs() as trap_sa:
                 trap_rc.perform_enqueued_jobs()
                 shipment_advice = self.channel.shipment_advice_ids
@@ -142,7 +142,7 @@ class TestStockReleaseChannelDeliverAsync(TestStockReleaseChannelDeliverCommon):
         with trap_jobs() as trap_rc:
             wizard.action_deliver()
             self.assertEqual(self.channel.state, "delivering")
-            trap_rc.assert_enqueued_job(self.channel._action_deliver)
+            trap_rc.assert_enqueued_job(self.channel._process_shipments)
             with trap_jobs() as trap_sa:
                 trap_rc.perform_enqueued_jobs()
                 advices = self.channel.shipment_advice_ids.filtered(
@@ -166,7 +166,7 @@ class TestStockReleaseChannelDeliverAsync(TestStockReleaseChannelDeliverCommon):
         with trap_jobs() as trap_rc:
             self.channel.action_deliver()
             self.assertEqual(self.channel.state, "delivering")
-            trap_rc.assert_enqueued_job(self.channel._action_deliver)
+            trap_rc.assert_enqueued_job(self.channel._process_shipments)
             with trap_jobs() as trap_sa:
                 trap_rc.perform_enqueued_jobs()
                 advices = self.channel.shipment_advice_ids.filtered(

--- a/stock_release_channel_shipment_advice_deliver/wizards/stock_release_channel_deliver_check_wizard.py
+++ b/stock_release_channel_shipment_advice_deliver/wizards/stock_release_channel_deliver_check_wizard.py
@@ -14,4 +14,5 @@ class StockReleaseChannelDeliverCheckWizard(models.TransientModel):
     def action_deliver(self):
         self.ensure_one()
         self.release_channel_id.unrelease_picking()
-        return self.release_channel_id.action_deliver()
+        self.release_channel_id._action_deliver()
+        return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION


As we want to let the operator deliver even if a backorder still exists, show the confirmation wizard in that case (and not an error).